### PR TITLE
Add extensive comments across frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,13 +1,17 @@
 <!doctype html>
+<!-- Основной HTML-файл приложения. Здесь подключается корневой контейнер React -->
 <html lang="ru">
   <head>
+    <!-- Базовая конфигурация страницы и подключение иконки -->
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tour Guide Manager</title>
   </head>
   <body>
+    <!-- Элемент, в который React будет монтировать приложение -->
     <div id="root"></div>
+    <!-- Подключение главного скрипта сборки Vite -->
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,15 +6,22 @@ import Dashboard from './pages/Dashboard';
 import './App.css';
 import './components/GlobalStyles.css';
 
+// Клиент react-query для управления запросами к серверу
 const queryClient = new QueryClient();
 
+// Основной компонент приложения
 function App() {
   return (
+    // Провайдер переводов. Позволяет использовать функцию t() во всех компонентах
     <LanguageProvider>
+      {/* Провайдер react-query делает клиент доступным вложенным компонентам */}
       <QueryClientProvider client={queryClient}>
+        {/* Router управляет навигацией по страницам */}
         <Router>
           <div className="App">
+            {/* Определяем маршруты нашего приложения */}
             <Routes>
+              {/* Главная страница с дашбордом */}
               <Route path="/" element={<Dashboard />} />
               <Route path="/dashboard" element={<Dashboard />} />
             </Routes>

--- a/frontend/src/components/CalendarGrid.tsx
+++ b/frontend/src/components/CalendarGrid.tsx
@@ -3,12 +3,19 @@ import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, isToday
 import { Tour } from '../services/api';
 import './CalendarGrid.css';
 
+// Свойства компонента календаря
 interface CalendarGridProps {
+  // Выбранная дата, вокруг которой строится календарь
   selectedDate: Date;
+  // Список туров для отображения
   tours: Tour[];
+  // Обработчик клика по туру
   onTourClick: (tour: Tour) => void;
+  // Обработчик клика по дню календаря
   onDateClick: (date: Date) => void;
+  // Режим отображения (месяц/неделя/день)
   viewMode: 'month' | 'week' | 'day';
+  // Флаг загрузки данных
   isLoading: boolean;
 }
 
@@ -20,18 +27,21 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
   viewMode,
   isLoading
 }) => {
+  // Возвращает массив всех дней текущего месяца
   const getDaysInMonth = (date: Date) => {
     const start = startOfMonth(date);
     const end = endOfMonth(date);
     return eachDayOfInterval({ start, end });
   };
 
+  // Фильтрует туры по указанной дате
   const getToursForDate = (date: Date) => {
-    return tours.filter(tour => 
+    return tours.filter(tour =>
       isSameDay(new Date(tour.date), date)
     );
   };
 
+  // Определяем CSS-классы для отображения статуса тура
   const getTourStatusColor = (tour: Tour) => {
     switch (tour.status) {
       case 'confirmed':
@@ -45,6 +55,7 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
     }
   };
 
+  // Показываем спиннер загрузки, пока данные туров еще не получены
   if (isLoading) {
     return (
       <div className="calendar-grid loading">
@@ -53,36 +64,42 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
     );
   }
 
+  // Список дней текущего месяца
   const days = getDaysInMonth(selectedDate);
 
   return (
     <div className="calendar-grid">
+      {/* Заголовок с названием месяца */}
       <div className="calendar-header">
         <h2>{format(selectedDate, 'MMMM yyyy')}</h2>
       </div>
       
+      {/* Заголовок дней недели */}
       <div className="calendar-weekdays">
         {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(day => (
           <div key={day} className="weekday">{day}</div>
         ))}
       </div>
 
+      {/* Сетка дней месяца */}
       <div className="calendar-days">
         {days.map(day => {
           const dayTours = getToursForDate(day);
           const isCurrentDay = isToday(day);
           const isCurrentMonth = isSameMonth(day, selectedDate);
-          
+
           return (
             <div
               key={day.toISOString()}
               className={`calendar-day ${isCurrentDay ? 'today' : ''} ${!isCurrentMonth ? 'other-month' : ''}`}
               onClick={() => onDateClick(day)}
             >
+              {/* Номер дня */}
               <div className="day-number">
                 {format(day, 'd')}
               </div>
-              
+
+              {/* Список туров в этот день */}
               <div className="day-tours">
                 {dayTours.map(tour => (
                   <div
@@ -93,10 +110,13 @@ const CalendarGrid: React.FC<CalendarGridProps> = ({
                       onTourClick(tour);
                     }}
                   >
+                    {/* Время начала тура */}
                     <div className="tour-time">
                       {format(new Date(tour.date), 'HH:mm')}
                     </div>
+                    {/* Название тура */}
                     <div className="tour-name">{tour.name}</div>
+                    {/* Место проведения */}
                     <div className="tour-venue">{tour.venue}</div>
                   </div>
                 ))}

--- a/frontend/src/components/CreateTourModal.tsx
+++ b/frontend/src/components/CreateTourModal.tsx
@@ -6,9 +6,13 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { createTour, createClient, CreateTourData, CreateClientData, Client } from '../services/api';
 import './CreateTourModal.css';
 
+// Свойства модального окна создания тура
 interface CreateTourModalProps {
+  // Признак открытия окна
   open: boolean;
+  // Колбэк для изменения состояния (открыто/закрыто)
   onOpenChange: (open: boolean) => void;
+  // Список доступных клиентов
   clients: Client[];
 }
 
@@ -19,8 +23,10 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
 }) => {
   const { t } = useLanguage();
   const queryClient = useQueryClient();
+  // Инициализация формы для ввода данных тура
   const { register, handleSubmit, reset, watch, setValue, formState: { errors } } = useForm<CreateTourData>();
 
+  // Мутация для отправки нового тура на сервер
   const createTourMutation = useMutation(createTour, {
     onSuccess: () => {
       queryClient.invalidateQueries('tours');
@@ -32,19 +38,23 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
     }
   });
 
+  // Мутация для создания нового клиента прямо из формы тура
   const createClientMutation = useMutation(createClient, {
     onSuccess: () => {
       queryClient.invalidateQueries('clients');
     },
   });
 
+  // Показывать ли форму добавления нового клиента
   const [showNewClient, setShowNewClient] = useState(false);
+  // Данные нового клиента
   const [newClient, setNewClient] = useState<CreateClientData>({
     name: '',
     contact_info: '',
     tg_alias: '',
   });
 
+  // Отправка формы создания тура
   const onSubmit = async (data: CreateTourData) => {
     let clientId = data.client_id;
     if (data.client_id === 'new') {
@@ -61,11 +71,13 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
     });
   };
 
+  // Если окно закрыто, ничего не рендерим
   if (!open) return null;
 
   return (
     <div className="modal-overlay">
       <div className="modal-content">
+        {/* Заголовок модального окна */}
         <div className="modal-header">
           <h2>{t('create_tour')}</h2>
           <button
@@ -76,6 +88,7 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
           </button>
         </div>
 
+        {/* Форма создания тура */}
         <form onSubmit={handleSubmit(onSubmit)} className="tour-form">
           <div className="form-group">
             <label htmlFor="name">{t('tour_name')}</label>
@@ -89,6 +102,7 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
 
           <div className="form-group">
             <label htmlFor="description">{t('description')}</label>
+            {/* Описание тура */}
             <textarea
               id="description"
               {...register('description')}
@@ -102,6 +116,7 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
               <label htmlFor="date">{t('date')} & {t('time')}</label>
               <div className="input-with-icon">
                 <Calendar size={16} />
+                {/* Дата и время тура */}
                 <input
                   id="date"
                   type="datetime-local"
@@ -115,6 +130,7 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
               <label htmlFor="duration">{t('duration')}</label>
               <div className="input-with-icon">
                 <Clock size={16} />
+                {/* Продолжительность экскурсии в часах */}
                 <input
                   id="duration"
                   type="number"
@@ -132,6 +148,7 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
             <label htmlFor="venue">{t('venue')}</label>
             <div className="input-with-icon">
               <MapPin size={16} />
+              {/* Место проведения тура */}
               <input
                 id="venue"
                 {...register('venue', { required: 'Venue is required' })}
@@ -146,6 +163,7 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
               <label htmlFor="group_size">{t('group_size')}</label>
               <div className="input-with-icon">
                 <Users size={16} />
+                {/* Размер группы */}
                 <input
                   id="group_size"
                   type="number"
@@ -161,6 +179,7 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
               <label htmlFor="price">{t('price')}</label>
               <div className="input-with-icon">
                 <DollarSign size={16} />
+                {/* Стоимость экскурсии */}
                 <input
                   id="price"
                   type="number"
@@ -197,6 +216,7 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
 
             {showNewClient && (
               <div className="add-client-form">
+                {/* Форма добавления нового клиента */}
                 <input
                   type="text"
                   placeholder="Client name"
@@ -220,6 +240,7 @@ const CreateTourModal: React.FC<CreateTourModalProps> = ({
           </div>
 
           <div className="form-actions">
+            {/* Кнопки управления формой */}
             <button
               type="button"
               onClick={() => onOpenChange(false)}

--- a/frontend/src/components/ManageGuidesModal.tsx
+++ b/frontend/src/components/ManageGuidesModal.tsx
@@ -6,8 +6,11 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { createGuide, CreateGuideData, fetchGuides, Guide } from '../services/api';
 import './ManageGuidesModal.css';
 
+// Свойства модального окна управления гидами
 interface ManageGuidesModalProps {
+  // Признак открытия окна
   open: boolean;
+  // Колбэк для изменения состояния
   onOpenChange: (open: boolean) => void;
 }
 
@@ -17,10 +20,13 @@ const ManageGuidesModal: React.FC<ManageGuidesModalProps> = ({
 }) => {
   const { t } = useLanguage();
   const queryClient = useQueryClient();
+  // Форма для добавления нового гида
   const { register, handleSubmit, reset, formState: { errors } } = useForm<CreateGuideData>();
 
+  // Загружаем список гидов
   const { data: guides = [], isLoading } = useQuery('guides', fetchGuides);
 
+  // Мутация для добавления гида
   const createGuideMutation = useMutation(createGuide, {
     onSuccess: () => {
       queryClient.invalidateQueries('guides');
@@ -31,15 +37,18 @@ const ManageGuidesModal: React.FC<ManageGuidesModalProps> = ({
     }
   });
 
+  // Отправка формы добавления гида
   const onSubmit = (data: CreateGuideData) => {
     createGuideMutation.mutate(data);
   };
 
+  // Если окно закрыто, ничего не отображаем
   if (!open) return null;
 
   return (
     <div className="modal-overlay">
       <div className="modal-content large">
+        {/* Заголовок модального окна */}
         <div className="modal-header">
           <h2>Manage Guides</h2>
           <button
@@ -62,6 +71,7 @@ const ManageGuidesModal: React.FC<ManageGuidesModalProps> = ({
                 ) : (
                   guides.map((guide: Guide) => (
                     <div key={guide.id} className="guide-item">
+                      {/* Информация о гиде */}
                       <div className="guide-info">
                         <h4>{guide.name}</h4>
                         <div className="guide-details">
@@ -70,6 +80,7 @@ const ManageGuidesModal: React.FC<ManageGuidesModalProps> = ({
                           {guide.tg_alias && <span><MessageCircle size={14} /> @{guide.tg_alias}</span>}
                         </div>
                       </div>
+                      {/* Статистика по гиду */}
                       <div className="guide-stats">
                         <span className="tours-count">{guide.total_tours} tours</span>
                         <span className="earnings">${guide.total_earnings}</span>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -4,22 +4,31 @@ import { useLanguage } from '../contexts/LanguageContext';
 import './Sidebar.css';
 
 interface SidebarProps {
+  // Текущая выбранная дата
   selectedDate: Date;
+  // Срабатывает при выборе другой даты
   onDateChange: (date: Date) => void;
+  // Режим отображения календаря
   viewMode: 'month' | 'week' | 'day';
+  // Изменение режима отображения
   onViewModeChange: (mode: 'month' | 'week' | 'day') => void;
+  // Фильтр по статусу туров
   statusFilters: {
     confirmed: boolean;
     pending: boolean;
     'guide-needed': boolean;
   };
+  // Обработчик изменения фильтров
   onStatusFiltersChange: (filters: any) => void;
+  // Статистические данные
   stats: {
     totalTours: number;
     confirmedTours: number;
     pendingTours: number;
   };
+  // Открыть модальное окно создания тура
   onCreateTour: () => void;
+  // Открыть окно управления гидами
   onManageGuides: () => void;
 }
 
@@ -37,16 +46,18 @@ const Sidebar: React.FC<SidebarProps> = ({
   const { t } = useLanguage();
   return (
     <div className="sidebar">
+      {/* Логотип/заголовок */}
       <div className="sidebar-header">
         <h1>Tour Guide Manager</h1>
       </div>
 
+      {/* Кнопки действий */}
       <div className="sidebar-actions">
         <button onClick={onCreateTour} className="create-tour-btn">
           <Plus size={16} />
           {t('create_tour')}
         </button>
-        
+
         <button onClick={onManageGuides} className="manage-guides-btn">
           <Users size={16} />
           {t('manage_guides')}
@@ -55,6 +66,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
       <div className="sidebar-section">
         <h3><Calendar size={16} /> {t('calendar')}</h3>
+        {/* Выбор даты */}
         <input
           type="date"
           value={selectedDate.toISOString().split('T')[0]}
@@ -65,6 +77,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
       <div className="sidebar-section">
         <h3>{t('view_mode')}</h3>
+        {/* Переключатели режима отображения календаря */}
         <div className="view-modes">
           {(['month', 'week', 'day'] as const).map(mode => (
             <button
@@ -80,6 +93,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
       <div className="sidebar-section">
         <h3><Filter size={16} /> {t('filters')}</h3>
+        {/* Фильтры по статусу туров */}
         <div className="status-filters">
           {Object.entries(statusFilters).map(([status, enabled]) => (
             <label key={status} className="filter-checkbox">
@@ -100,6 +114,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
       <div className="sidebar-section">
         <h3><BarChart3 size={16} /> {t('statistics')}</h3>
+        {/* Небольшая статистика по турам */}
         <div className="stats">
           <div className="stat-item">
             <span className="stat-label">{t('total_tours_count')}</span>

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -1,11 +1,14 @@
 import { createContext, useContext, ReactNode } from 'react';
 
+// Тип контекста: функция t для получения перевода строки
 interface LanguageContextType {
   t: (key: string) => string;
 }
 
+// Создаем сам контекст
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
 
+// Словарь переводов (пока только русский язык)
 const translations = {
   ru: {
     // Navigation
@@ -85,7 +88,9 @@ const translations = {
   }
 };
 
+// Провайдер контекста, используем его в корне приложения
 export const LanguageProvider = ({ children }: { children: ReactNode }) => {
+  // Функция для получения перевода по ключу
   const t = (key: string): string => {
     return translations.ru[key as keyof typeof translations.ru] || key;
   };
@@ -97,6 +102,7 @@ export const LanguageProvider = ({ children }: { children: ReactNode }) => {
   );
 };
 
+// Хук для доступа к контексту языка
 export const useLanguage = () => {
   const context = useContext(LanguageContext);
   if (context === undefined) {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,8 +3,12 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
+// Точка входа в React‑приложение.
+// Создаем корневой ReactDOM и монтируем компонент App.
 ReactDOM.createRoot(document.getElementById('root')!).render(
+  // StrictMode помогает выявлять потенциальные проблемы в приложении
   <React.StrictMode>
+    {/* Основной компонент приложения */}
     <App />
   </React.StrictMode>,
 );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -10,11 +10,17 @@ import './Dashboard.css';
 
 export default function Dashboard() {
   const { t } = useLanguage();
+
+  // Текущая выбранная дата в календаре
   const [selectedDate, setSelectedDate] = useState(new Date());
+  // Режим отображения календаря: месяц/неделя/день
   const [viewMode, setViewMode] = useState<'month' | 'week' | 'day'>('month');
+  // Выбранный тур (когда пользователь кликает по карточке)
   const [selectedTour, setSelectedTour] = useState<Tour | null>(null);
+  // Состояния открытия модальных окон
   const [createTourOpen, setCreateTourOpen] = useState(false);
   const [manageGuidesOpen, setManageGuidesOpen] = useState(false);
+  // Фильтры по статусу туров
   const [statusFilters, setStatusFilters] = useState({
     confirmed: true,
     pending: true,
@@ -23,33 +29,39 @@ export default function Dashboard() {
 
   // const queryClient = useQueryClient();
 
+  // Получаем данные туров с сервера и автоматически обновляем их каждые 30 секунд
   const { data: tours = [], isLoading: toursLoading } = useQuery(
     'tours',
     fetchTours,
     { refetchInterval: 30000 }
   );
 
+  // Получаем списки клиентов и гидов
   const { data: clients = [] } = useQuery('clients', fetchClients);
   const { data: guides = [] } = useQuery('guides', fetchGuides);
 
+  // Статистика для сайдбара
   const stats = {
     totalTours: tours.length,
     confirmedTours: tours.filter(tour => tour.status === 'confirmed').length,
     pendingTours: tours.filter(tour => tour.status === 'pending').length,
   };
 
+  // Применяем фильтры статуса к списку туров
   const filteredTours = tours.filter(tour => {
     return statusFilters[tour.status as keyof typeof statusFilters];
   });
 
   return (
     <div className="dashboard">
+      {/* Шапка страницы */}
       <div className="dashboard-header">
         <div className="header-content">
           <h1 className="text-2xl font-bold text-gray-800">{t('dashboard')}</h1>
         </div>
       </div>
 
+      {/* Основная часть с сайдбаром и календарем */}
       <div className="dashboard-body">
         <Sidebar
           selectedDate={selectedDate}
@@ -62,7 +74,8 @@ export default function Dashboard() {
           onCreateTour={() => setCreateTourOpen(true)}
           onManageGuides={() => setManageGuidesOpen(true)}
         />
-        
+
+        {/* Содержимое календаря */}
         <main className="main-content">
           <CalendarGrid
             selectedDate={selectedDate}
@@ -75,12 +88,14 @@ export default function Dashboard() {
         </main>
       </div>
 
+      {/* Модальное окно создания тура */}
       <CreateTourModal
         open={createTourOpen}
         onOpenChange={setCreateTourOpen}
         clients={clients}
       />
 
+      {/* Модальное окно управления гидами */}
       <ManageGuidesModal
         open={manageGuidesOpen}
         onOpenChange={setManageGuidesOpen}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+// Базовый URL для всех запросов к серверу
 const API_BASE_URL = '/api';
 
+// Экземпляр axios с общими настройками
 const api = axios.create({
   baseURL: API_BASE_URL,
   headers: {
@@ -9,6 +11,7 @@ const api = axios.create({
   },
 });
 
+// Описание типов данных, которые возвращает API
 export interface Client {
   id: number;
   name: string;
@@ -74,7 +77,7 @@ export interface CreateClientData {
   black_list?: boolean;
 }
 
-// Tours API
+// --- Методы работы с турами ---
 export const fetchTours = async (): Promise<Tour[]> => {
   const response = await api.get('/tours');
   return response.data;
@@ -104,7 +107,7 @@ export const assignGuideToTour = async (tourId: number, guideId: number): Promis
   return response.data;
 };
 
-// Clients API
+// --- Методы работы с клиентами ---
 export const fetchClients = async (): Promise<Client[]> => {
   const response = await api.get('/clients');
   return response.data;
@@ -115,7 +118,7 @@ export const createClient = async (clientData: CreateClientData): Promise<Client
   return response.data;
 };
 
-// Guides API
+// --- Методы работы с гидами ---
 export const fetchGuides = async (): Promise<Guide[]> => {
   const response = await api.get('/guides');
   return response.data;


### PR DESCRIPTION
## Summary
- document HTML root and main entry point
- add in-depth comments to App setup, Dashboard page, and components
- document API service and language context

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858fde1fbe88329b7a7d571e400415b